### PR TITLE
feat: Implement web interface for remote sound playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,30 @@ This is neccessary because you want others to hear your own beautiful voice whil
 4. Pipe your microphone through the Virtual Cable as well by going into the `sound control panel -> recording -> properties (right click on your mic) -> listen`. Now tick `Listen to this device` and select `CABLE Input`.
 5. Done! Now you can use `CABLE Output` in any app as device and others can hear your voice and the soundboard at the same time.
 
+
+## Web Interface (Remote Control)
+
+This soundboard includes a web interface that allows you to control sound playback remotely from another device on your local network (e.g., a smartphone, tablet, or another computer).
+
+### Accessing the Remote Control
+
+1.  **Find Host IP Address**: You need to determine the IP address of the computer where the Electron Soundboard application is running.
+    *   On Windows, you can typically find this by opening Command Prompt and typing `ipconfig`. Look for the "IPv4 Address" under your active network adapter.
+    *   On macOS, open System Preferences > Network, select your active connection, and the IP address will be displayed. Or, use `ifconfig` in the Terminal.
+    *   On Linux, use the `ip addr` or `ifconfig` command in the Terminal.
+
+2.  **Open in Browser**: On your remote device (e.g., smartphone or another computer connected to the same local network), open a web browser.
+
+3.  **Navigate to URL**: Enter the following URL in the browser's address bar:
+    `http://<HOST_IP>:3001/remote.html`
+    Replace `<HOST_IP>` with the actual IP address you found in step 1. For example, if the host IP is `192.168.1.10`, you would navigate to `http://192.168.1.10:3001/remote.html`.
+
+    The port number for the remote interface is **3001**.
+
+### Using the Remote Control
+
+The web page will load and attempt to connect to the Electron Soundboard application.
+- It provides an input field where you should ensure the `<HOST_IP>` is correctly entered (it defaults to `localhost`, which will only work if you are opening the page on the same machine running the soundboard).
+- Buttons for each sound currently loaded in the soundboard application will be displayed.
+- Clicking a button on the web page will trigger the corresponding sound to play on the host machine where the Electron Soundboard is running.
+- If sounds are not loading, ensure the IP address is correct and try the "Refresh Sounds" button.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,14 @@ The web page will load and attempt to connect to the Electron Soundboard applica
 - Buttons for each sound currently loaded in the soundboard application will be displayed.
 - Clicking a button on the web page will trigger the corresponding sound to play on the host machine where the Electron Soundboard is running.
 - If sounds are not loading, ensure the IP address is correct and try the "Refresh Sounds" button.
+
+### Sound Icons
+
+You can associate icons with your sounds in the web remote interface. These icons will appear on the buttons corresponding to each sound.
+
+To enable this feature:
+1.  Ensure your image file is in the **same directory** as your sound file.
+2.  The image file must have the **exact same base name** as the sound file. For example, if your sound file is named `mysound.mp3`, your image file could be `mysound.png`.
+3.  The application supports the following image extensions: `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`. The first one found (in this order of preference, though the actual lookup order might vary) will be used.
+
+If a matching image is found, it will be displayed as an icon on the button for that sound in the web remote interface, making it easier to identify your sounds visually.

--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -6,7 +6,7 @@ import mime from 'mime'
 import express from 'express'
 import cors from 'cors'
 import { IpcMainEvent } from 'electron/main'
-import { autoUpdater } from "electron-updater"
+import { autoUpdater } from "electron-updater" 
 
 const fspromise = fs.promises
 
@@ -32,14 +32,14 @@ export default class Main {
     }
 
     private static onClose() {
-        // Dereference the window object.
+        // Dereference the window object. 
         // Main.mainWindow = null;
         console.log("closed")
     }
 
     private static onReady() {
-        Main.mainWindow = new Main.BrowserWindow({
-            width: 1460,
+        Main.mainWindow = new Main.BrowserWindow({ 
+            width: 1460, 
             height: 1000,
             minWidth: 760,
             minHeight: 50,
@@ -49,14 +49,14 @@ export default class Main {
                 contextIsolation: true,
                 enableRemoteModule: false,
                 preload: path.join(__dirname, 'preload.js')
-    }
+    } 
         });
         Main.mainWindow.loadURL(isDev ? 'http://localhost:3000' : `file://${path.join(__dirname, '../build/index.html')}`);
         Main.mainWindow.on('closed', Main.onClose);
 
+        
 
-
-
+        
 
         Main.mainWindow.on("minimize", (e) => {
             e.preventDefault();
@@ -67,15 +67,14 @@ export default class Main {
         autoUpdater.logger = log
 
         autoUpdater.on('error', (error) => {
-            console.log("error checking for updates!")
-            //dialog.showErrorBox('Error: ', error == null ? "unknown" : (error.stack || error).toString())
+            dialog.showErrorBox('Error: ', error == null ? "unknown" : (error.stack || error).toString())
         })
         if (!isDev) {
             autoUpdater.checkForUpdatesAndNotify()
             console.log("Checking for updates!")
         }
-
-
+        
+        
 
         var contextMenu = Menu.buildFromTemplate([
             {
@@ -163,11 +162,11 @@ export default class Main {
                     fileNames.push(file)
                 }
             }
-
+            
         })
 
         return [paths, fileNames]
-
+    
     }
 
     private static listenerListFiles() {
@@ -179,7 +178,7 @@ export default class Main {
                 }));
 
                 let load = {
-                    dir: dir,
+                    dir: dir, 
                     paths: paths,
                     fileNames: fileNames 
                 }
@@ -198,7 +197,7 @@ export default class Main {
         // Response Object contains the Selection path and all the audio files in the dir
         // -------------------------------------
 
-        ipcMain.handle('APP_showDialog', (event, ...args) => {
+        ipcMain.handle('APP_showDialog', (event, ...args) => {  
             let dir : string = ''
 
             dialog.showOpenDialog({properties: ['openDirectory']})
@@ -244,19 +243,19 @@ export default class Main {
         })
     }
 
+    
 
-
-
+    
 
     private static listenerHotkey() {
-        let keys : string[] = [] // Keep track of keys
+        let keys : string[] = [] // Keep track of keys 
         let names : string[] = [] // Corrosponding File Names for Shortcuts
 
         let bindings : Bind[] = []
 
         ipcMain.on('APP_setkey', (event, key : string, title : string, ...args) => {
-
-            let keyIndex = names.indexOf(title) // Check if a Shortcut is already registered
+            
+            let keyIndex = names.indexOf(title) // Check if a Shortcut is already registered 
             let exists = false
 
             for (let bind of bindings) {
@@ -306,22 +305,22 @@ export default class Main {
         } )
     }
 
-
+        
 
     static main(app: Electron.App, browserWindow: typeof BrowserWindow) {
-        // we pass the Electron.App object and the
-        // Electron.BrowserWindow into this function
-        // so this class has no dependencies. This
-        // makes the code easier to write tests for
+        // we pass the Electron.App object and the  
+        // Electron.BrowserWindow into this function 
+        // so this class has no dependencies. This 
+        // makes the code easier to write tests for 
         Main.BrowserWindow = browserWindow;
-
+        
         Main.application = app;
         Main.application.on('window-all-closed', Main.onWindowAllClosed);
         Main.application.on('ready', Main.onReady);
-
-
-
-
+        
+        
+        
+        
 
         this.listenerFileSelection()
         this.listenerHotkey()
@@ -336,3 +335,4 @@ export default class Main {
 
 
 Main.main(app, BrowserWindow)
+

--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -108,6 +108,14 @@ export default class Main {
         const expressApp = express();
         const port = 3001;
 
+        // Serve static files from the 'build' directory (where electron.js is located)
+        // This should make remote.html accessible if it's in 'build/remote.html' or 'build/public/remote.html'
+        // depending on the build process.
+        expressApp.use(express.static(__dirname)); 
+        // If remote.html is in build/public/remote.html, use:
+        // expressApp.use('/public', express.static(path.join(__dirname, 'public')));
+        // or adjust remote.html path to be /public/remote.html
+
         expressApp.use(cors());
 
         expressApp.get('/hello', (req, res) => {

--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -160,8 +160,9 @@ export default class Main {
             res.json(soundsWithDataUrls);
         });
 
-        expressApp.listen(port, () => {
-            console.log(`Express server listening on port ${port}`);
+        expressApp.listen(port, '0.0.0.0', () => {
+            console.log(`Express server listening on port ${port}. Accessible on your local network.`);
+            console.log(`Try: http://<YOUR_MACHINE_IP>:${port}/remote.html`);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "express": "^4.17.1",
+    "cors": "^2.8.5"
   },
   "scripts": {
     "react-start": "yarn compile | react-scripts start",
@@ -88,6 +90,8 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
     "concurrently": "^5.3.0",
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",

--- a/package.json
+++ b/package.json
@@ -8,20 +8,19 @@
     "name": "Manuel",
     "email": "test@test.com"
   },
-  "description": "A simple Electron soundboard application with remote control capabilities.",
   "dependencies": {
     "@types/dom-mediacapture-record": "^1.0.7",
     "@types/mime": "^2.0.3",
-    "cors": "^2.8.5",
     "electron-is-dev": "^1.2.0",
     "electron-log": "^4.3.1",
     "electron-updater": "^4.3.5",
-    "express": "^4.17.1",
     "mime": "^2.5.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "express": "^4.17.1",
+    "cors": "^2.8.5"
   },
   "scripts": {
     "react-start": "yarn compile | react-scripts start",
@@ -87,12 +86,12 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.21",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.17",
     "concurrently": "^5.3.0",
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",

--- a/package.json
+++ b/package.json
@@ -8,19 +8,20 @@
     "name": "Manuel",
     "email": "test@test.com"
   },
+  "description": "A simple Electron soundboard application with remote control capabilities.",
   "dependencies": {
     "@types/dom-mediacapture-record": "^1.0.7",
     "@types/mime": "^2.0.3",
+    "cors": "^2.8.5",
     "electron-is-dev": "^1.2.0",
     "electron-log": "^4.3.1",
     "electron-updater": "^4.3.5",
+    "express": "^4.17.1",
     "mime": "^2.5.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
-    "web-vitals": "^0.2.4",
-    "express": "^4.17.1",
-    "cors": "^2.8.5"
+    "web-vitals": "^0.2.4"
   },
   "scripts": {
     "react-start": "yarn compile | react-scripts start",
@@ -86,12 +87,12 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
     "@types/jest": "^26.0.15",
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
-    "@types/express": "^4.17.21",
-    "@types/cors": "^2.8.17",
     "concurrently": "^5.3.0",
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",

--- a/public/remote.html
+++ b/public/remote.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Soundboard Remote</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        #sound-buttons-container button { margin: 5px; padding: 10px 15px; border: none; background-color: #5cb85c; color: white; cursor: pointer; border-radius: 5px; }
+        #sound-buttons-container button:hover { background-color: #4cae4c; }
+        input[type="text"] { padding: 8px; margin-right: 10px; border-radius: 3px; border: 1px solid #ccc; }
+        h1 { color: #333; }
+        p { margin-bottom: 15px; }
+    </style>
+</head>
+<body>
+    <h1>Soundboard Remote</h1>
+    <p>
+        Enter Electron Host IP: <input type="text" id="host-ip" value="localhost">
+        <button id="refresh-sounds">Refresh Sounds (using placeholder)</button>
+    </p>
+    <div id="sound-buttons-container">
+        <!-- Sound buttons will be dynamically added here -->
+    </div>
+
+    <script>
+        const soundButtonsContainer = document.getElementById('sound-buttons-container');
+        const hostIpInput = document.getElementById('host-ip');
+        const refreshButton = document.getElementById('refresh-sounds');
+
+        // Placeholder sounds - replace with fetch to /get-sounds from Electron Express server later
+        let sounds = [
+            { name: 'sound1.mp3' },
+            { name: 'example.wav' },
+            { name: 'another_sound.ogg' }
+        ];
+
+        // Function to fetch sounds from the server (currently placeholder)
+        async function fetchSounds() {
+            const hostIp = hostIpInput.value || 'localhost';
+            // Replace with actual fetch when /get-sounds is implemented
+            // For now, we just re-use the placeholder or simulate a fetch.
+            console.log(`Fetching sounds from http://${hostIp}:3001/get-sounds (placeholder active)`);
+            try {
+                // const response = await fetch(`http://${hostIp}:3001/get-sounds`);
+                // if (!response.ok) {
+                //     throw new Error(`HTTP error! status: ${response.status}`);
+                // }
+                // sounds = await response.json();
+                // console.log('Sounds loaded:', sounds);
+                
+                // Using placeholder:
+                console.log('Using placeholder sounds array as /get-sounds is not yet implemented.');
+            } catch (error) {
+                console.error('Error fetching sounds:', error);
+                soundButtonsContainer.innerHTML = '<p>Error loading sounds. Check console and IP.</p>';
+                sounds = []; // Clear sounds on error
+            }
+            renderButtons(); // Re-render buttons with new/old sounds
+        }
+
+        function renderButtons() {
+            soundButtonsContainer.innerHTML = ''; // Clear existing buttons
+            const hostIp = hostIpInput.value || 'localhost';
+
+            if (sounds.length === 0) {
+                soundButtonsContainer.innerHTML = '<p>No sounds loaded. Try refreshing or check IP.</p>';
+                return;
+            }
+
+            sounds.forEach(sound => {
+                if (!sound || typeof sound.name !== 'string') {
+                    console.warn('Invalid sound object in sounds array:', sound);
+                    return; 
+                }
+                const button = document.createElement('button');
+                // Display name without extension
+                const nameWithoutExtension = sound.name.split('.').slice(0, -1).join('.') || sound.name;
+                button.textContent = nameWithoutExtension;
+                
+                button.onclick = () => {
+                    console.log(`Requesting to play: ${sound.name} via http://${hostIp}:3001`);
+                    fetch(`http://${hostIp}:3001/play-sound/${encodeURIComponent(sound.name)}`)
+                        .then(response => {
+                            if (!response.ok) {
+                                return response.json().then(err => { throw new Error(`Server error: ${err.message || response.status }`) });
+                            }
+                            return response.json();
+                        })
+                        .then(data => console.log('Play request response:', data))
+                        .catch(error => console.error('Error playing sound:', error));
+                };
+                soundButtonsContainer.appendChild(button);
+            });
+        }
+
+        hostIpInput.addEventListener('change', fetchSounds); // Re-fetch (and re-render) if IP changes
+        refreshButton.addEventListener('click', fetchSounds); // Button to manually trigger fetch (and re-render)
+        
+        // Initial load and render
+        fetchSounds(); 
+    </script>
+</body>
+</html>

--- a/public/remote.html
+++ b/public/remote.html
@@ -6,18 +6,37 @@
     <title>Soundboard Remote</title>
     <style>
         body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
-        #sound-buttons-container button { margin: 5px; padding: 10px 15px; border: none; background-color: #5cb85c; color: white; cursor: pointer; border-radius: 5px; }
+        #sound-buttons-container button { 
+            margin: 5px; 
+            padding: 10px 15px; 
+            border: none; 
+            background-color: #5cb85c; 
+            color: white; 
+            cursor: pointer; 
+            border-radius: 5px; 
+            display: flex; /* For aligning image and text */
+            align-items: center; /* Vertically align items in button */
+            min-width: 150px; /* Ensure buttons have some width */
+            justify-content: center; /* Center content if only text */
+        }
         #sound-buttons-container button:hover { background-color: #4cae4c; }
+        #sound-buttons-container button img {
+            max-width: 40px;
+            max-height: 40px;
+            vertical-align: middle;
+            margin-right: 8px;
+        }
         input[type="text"] { padding: 8px; margin-right: 10px; border-radius: 3px; border: 1px solid #ccc; }
         h1 { color: #333; }
         p { margin-bottom: 15px; }
+        #sound-buttons-container { display: flex; flex-wrap: wrap; } /* Allow buttons to wrap */
     </style>
 </head>
 <body>
     <h1>Soundboard Remote</h1>
     <p>
         Enter Electron Host IP: <input type="text" id="host-ip" value="localhost">
-        <button id="refresh-sounds">Refresh Sounds (using placeholder)</button>
+        <button id="refresh-sounds">Refresh Sounds</button>
     </p>
     <div id="sound-buttons-container">
         <!-- Sound buttons will be dynamically added here -->
@@ -28,32 +47,29 @@
         const hostIpInput = document.getElementById('host-ip');
         const refreshButton = document.getElementById('refresh-sounds');
 
-        // Placeholder sounds - replace with fetch to /get-sounds from Electron Express server later
-        let sounds = [
-            { name: 'sound1.mp3' },
-            { name: 'example.wav' },
-            { name: 'another_sound.ogg' }
-        ];
+        let sounds = []; // Will be populated by fetchSounds
 
-        // Function to fetch sounds from the server (currently placeholder)
         async function fetchSounds() {
             const hostIp = hostIpInput.value || 'localhost';
-            // Replace with actual fetch when /get-sounds is implemented
-            // For now, we just re-use the placeholder or simulate a fetch.
-            console.log(`Fetching sounds from http://${hostIp}:3001/get-sounds (placeholder active)`);
+            console.log(`Fetching sounds from http://${hostIp}:3001/get-sounds`);
+            soundButtonsContainer.innerHTML = '<p>Loading sounds...</p>'; // Indicate loading
             try {
                 const response = await fetch(`http://${hostIp}:3001/get-sounds`);
                 if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+                    let errorText = `HTTP error! status: ${response.status}`;
+                    try {
+                        const errorData = await response.json();
+                        errorText += `, Message: ${errorData.message || 'Unknown server error'}`;
+                    } catch (e) {
+                        // Ignore if response is not JSON
+                    }
+                    throw new Error(errorText);
                 }
                 sounds = await response.json();
                 console.log('Sounds loaded:', sounds);
-
-                // Using placeholder:
-                console.log('Using placeholder sounds array as /get-sounds is not yet implemented.');
             } catch (error) {
                 console.error('Error fetching sounds:', error);
-                soundButtonsContainer.innerHTML = '<p>Error loading sounds. Check console and IP.</p>';
+                soundButtonsContainer.innerHTML = `<p>Error loading sounds: ${error.message}. Check console and IP.</p>`;
                 sounds = []; // Clear sounds on error
             }
             renderButtons(); // Re-render buttons with new/old sounds
@@ -63,21 +79,35 @@
             soundButtonsContainer.innerHTML = ''; // Clear existing buttons
             const hostIp = hostIpInput.value || 'localhost';
 
-            if (sounds.length === 0) {
-                soundButtonsContainer.innerHTML = '<p>No sounds loaded. Try refreshing or check IP.</p>';
+            if (!Array.isArray(sounds) || sounds.length === 0) {
+                if (!soundButtonsContainer.textContent.includes('Error loading sounds')) {
+                     soundButtonsContainer.innerHTML = '<p>No sounds loaded. Try refreshing or check IP.</p>';
+                }
                 return;
             }
 
             sounds.forEach(sound => {
                 if (!sound || typeof sound.name !== 'string') {
                     console.warn('Invalid sound object in sounds array:', sound);
-                    return;
+                    return; 
                 }
                 const button = document.createElement('button');
-                // Display name without extension
-                const nameWithoutExtension = sound.name.split('.').slice(0, -1).join('.') || sound.name;
-                button.textContent = nameWithoutExtension;
+                button.innerHTML = ''; // Clear any previous content
 
+                if (sound.imageDataUrl) {
+                    const img = document.createElement('img');
+                    img.src = sound.imageDataUrl;
+                    // Styles are now in CSS, but can be overridden or added to here if needed
+                    button.appendChild(img);
+                }
+
+                const buttonText = document.createElement('span');
+                // Display name without extension, or full name if no extension
+                const nameParts = sound.name.split('.');
+                const nameWithoutExtension = nameParts.length > 1 ? nameParts.slice(0, -1).join('.') : sound.name;
+                buttonText.textContent = nameWithoutExtension;
+                button.appendChild(buttonText);
+                
                 button.onclick = () => {
                     console.log(`Requesting to play: ${sound.name} via http://${hostIp}:3001`);
                     fetch(`http://${hostIp}:3001/play-sound/${encodeURIComponent(sound.name)}`)
@@ -94,11 +124,11 @@
             });
         }
 
-        hostIpInput.addEventListener('change', fetchSounds); // Re-fetch (and re-render) if IP changes
-        refreshButton.addEventListener('click', fetchSounds); // Button to manually trigger fetch (and re-render)
-
+        hostIpInput.addEventListener('change', fetchSounds);
+        refreshButton.addEventListener('click', fetchSounds);
+        
         // Initial load and render
-        fetchSounds();
+        fetchSounds(); 
     </script>
 </body>
 </html>

--- a/public/remote.html
+++ b/public/remote.html
@@ -42,13 +42,13 @@
             // For now, we just re-use the placeholder or simulate a fetch.
             console.log(`Fetching sounds from http://${hostIp}:3001/get-sounds (placeholder active)`);
             try {
-                // const response = await fetch(`http://${hostIp}:3001/get-sounds`);
-                // if (!response.ok) {
-                //     throw new Error(`HTTP error! status: ${response.status}`);
-                // }
-                // sounds = await response.json();
-                // console.log('Sounds loaded:', sounds);
-                
+                const response = await fetch(`http://${hostIp}:3001/get-sounds`);
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                sounds = await response.json();
+                console.log('Sounds loaded:', sounds);
+
                 // Using placeholder:
                 console.log('Using placeholder sounds array as /get-sounds is not yet implemented.');
             } catch (error) {
@@ -71,13 +71,13 @@
             sounds.forEach(sound => {
                 if (!sound || typeof sound.name !== 'string') {
                     console.warn('Invalid sound object in sounds array:', sound);
-                    return; 
+                    return;
                 }
                 const button = document.createElement('button');
                 // Display name without extension
                 const nameWithoutExtension = sound.name.split('.').slice(0, -1).join('.') || sound.name;
                 button.textContent = nameWithoutExtension;
-                
+
                 button.onclick = () => {
                     console.log(`Requesting to play: ${sound.name} via http://${hostIp}:3001`);
                     fetch(`http://${hostIp}:3001/play-sound/${encodeURIComponent(sound.name)}`)
@@ -96,9 +96,9 @@
 
         hostIpInput.addEventListener('change', fetchSounds); // Re-fetch (and re-render) if IP changes
         refreshButton.addEventListener('click', fetchSounds); // Button to manually trigger fetch (and re-render)
-        
+
         // Initial load and render
-        fetchSounds(); 
+        fetchSounds();
     </script>
 </body>
 </html>

--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import React, { MouseEventHandler, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 const { myIpcRenderer } = window
 
@@ -19,8 +19,6 @@ const constraints = {
 
 const Recorder : React.FunctionComponent = () => {
 
-    const videoRef = useRef<HTMLVideoElement>(null)
-    const audioRef = useRef<HTMLAudioElement>(null)
     const chunksRef = useRef<Blob[]>([])
     const recorderRef = useRef<MediaRecorder | null>()
     const [recording, setRecording] = useState<boolean>(false)

--- a/src/Recorder.tsx
+++ b/src/Recorder.tsx
@@ -1,5 +1,5 @@
 import './App.css';
-import React, { useEffect, useRef, useState } from 'react'
+import React, { MouseEventHandler, useEffect, useRef, useState } from 'react'
 
 const { myIpcRenderer } = window
 
@@ -19,6 +19,8 @@ const constraints = {
 
 const Recorder : React.FunctionComponent = () => {
 
+    const videoRef = useRef<HTMLVideoElement>(null)
+    const audioRef = useRef<HTMLAudioElement>(null)
     const chunksRef = useRef<Blob[]>([])
     const recorderRef = useRef<MediaRecorder | null>()
     const [recording, setRecording] = useState<boolean>(false)

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react'
+import { readlink } from 'fs'
+import React, { useRef, useState, useEffect } from 'react'
 import Pad from './pad'
 import Recorder from './Recorder'
 const { myIpcRenderer } = window
@@ -37,56 +38,63 @@ const Controller : React.FunctionComponent = () => {
         localStorage.setItem('secondary_output', event.currentTarget.value)
     }
 
-    const loadConfig = useCallback(() => {
+    const loadConfig = () => {
+
         // Load primary and secondary output settings
-        let output_1 = localStorage.getItem('primary_output');
-        if (output_1) setSelectedPrimaryOutput(output_1);
 
-        if (primaryRef.current) { // Check if ref is available
-            var optionsPrimary = Array.from(primaryRef.current.options);
-            optionsPrimary.forEach((option) => { // Use forEach for iteration without map's return
-                if (option.value === output_1) {
-                    option.selected = true;
-                }
-            });
-        }
+        let output_1 = localStorage.getItem('primary_output')
+        if (output_1) setSelectedPrimaryOutput(output_1)
+
+        let ref = primaryRef.current!
+        var options = Array.from(ref.options)
         
-        let output_2 = localStorage.getItem('secondary_output');
-        if (output_2) setSelectedSecondaryOutput(output_2);
+        options.map((option, i) => {
+            if (option.value === output_1) {
+                option.selected = true
+            }
+            return 0
+        })
+        
+        let output_2 = localStorage.getItem('secondary_output')
+        if (output_2) setSelectedSecondaryOutput(output_2)
 
-        if (secondaryRef.current) { // Check if ref is available
-            var optionsSecondary = Array.from(secondaryRef.current.options);
-            optionsSecondary.forEach((option) => { // Use forEach
-                if (option.value === output_2) {
-                    option.selected = true;
-                }
-            });
-        }
+        ref = secondaryRef.current!
+        options = Array.from(ref.options)
+        
+        options.map((option, i) => {
+            if (option.value === output_2) {
+                option.selected = true
+            }
+            return 0
+        })
 
         // Load Pad File Paths and names
+
         let loaded_paths = localStorage.getItem("paths");
-        if (loaded_paths) setPaths(JSON.parse(loaded_paths));
+        if (loaded_paths) setPaths(JSON.parse(loaded_paths))
 
         let loaded_names = localStorage.getItem("names");
-        if (loaded_names) setPadNames(JSON.parse(loaded_names));
+        if (loaded_names) setPadNames(JSON.parse(loaded_names))
 
         // Load Volume Sliders
-        let loaded_virtualVolume = localStorage.getItem("virtualVolume");
-        if (loaded_virtualVolume && virtualVolumeRef.current) { // Check ref
-            const virtualVolumeValue = parseFloat(loaded_virtualVolume);
-            setVirtualVolume(virtualVolumeValue);
-            setSliderStyle(virtualVolumeRef.current, virtualVolumeValue);
-            virtualVolumeRef.current.value = (virtualVolumeValue * 50).toString();
+
+        let loaded_virtualVolume = localStorage.getItem("virtualVolume")
+        if (loaded_virtualVolume) {
+            setVirtualVolume(parseFloat(loaded_virtualVolume))
+            setSliderStyle(virtualVolumeRef.current!, parseFloat(loaded_virtualVolume))
+            virtualVolumeRef.current!.value = (parseFloat(loaded_virtualVolume) * 50).toString() // Scale back to 0 - 50
         }
         
-        let loaded_volume = localStorage.getItem("volume");
-        if (loaded_volume && volumeRef.current) { // Check ref
-            const volumeValue = parseFloat(loaded_volume);
-            setVolume(volumeValue);
-            setSliderStyle(volumeRef.current, volumeValue);
-            volumeRef.current.value = (volumeValue * 50).toString();
+
+        let loaded_volume = localStorage.getItem("volume")
+        if (loaded_volume) {
+            setVolume(parseFloat(loaded_volume))
+            setSliderStyle(volumeRef.current!, parseFloat(loaded_volume))
+            volumeRef.current!.value = (parseFloat(loaded_volume) * 50).toString() // Scale back to 0 - 50
         }
-    }, [setSliderStyle, setSelectedPrimaryOutput, setPaths, setPadNames, setVirtualVolume, setVolume, setSelectedSecondaryOutput, primaryRef, secondaryRef, volumeRef, virtualVolumeRef]);
+
+    
+    }
 
     useEffect(() => {    
         // -------------------------------
@@ -99,7 +107,7 @@ const Controller : React.FunctionComponent = () => {
             .then( devices => {
                 devices = devices.filter((output) => output.kind === "audiooutput")
                 setOutputs(devices)
-                loadConfig() 
+                loadConfig()
             })
         
         const removeListedFilesListener = myIpcRenderer.on('APP_listedFiles', (result) => {
@@ -131,15 +139,15 @@ const Controller : React.FunctionComponent = () => {
                 removePlaySoundListener();
             }
         };
-    }, [loadConfig]);
+    }, [])
     
     const handlePathSelection = () => {
         myIpcRenderer.invoke('APP_showDialog')
     }
 
-    const setSliderStyle = useCallback((e: HTMLInputElement, progress: number) => {
-        e.style.background = 'linear-gradient(to right, #d08770 0%, #d08770 ' + progress * 100 + '%, #3b4252 ' + progress * 100 + '%, #3b4252 100%)';
-    }, []);
+    const setSliderStyle = (e: HTMLInputElement, progress : number) => {
+        e.style.background = 'linear-gradient(to right, #d08770 0%, #d08770 ' + progress * 100 + '%, #3b4252 ' + progress * 100 + '%, #3b4252 100%)' // Just CSS Stuff to make the slider work
+    }
 
     const handleVirtualVolumeChange = (e:React.FormEvent<HTMLInputElement>) => {
         let val = parseFloat(e.currentTarget.value)/50  // Scale Input to 0.0 - 1.0

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -10,13 +10,13 @@ interface PadProps {
     name: string | undefined;
     volume: number;
     virtualVolume: number;
-    registerPlayFunction?: (name: string, playFn: () => void) => void;
+    registerPlayFunction?: (name: string, playFn: () => void);
 }
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
 
 const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
-    const primaryAudioRef = useRef<ExtendedAudioElement>(null)
+    const primaryAudioRef = useRef<ExtendedAudioElement>(null) 
     const secondaryAudioRef = useRef<ExtendedAudioElement>(null)
 
     const [shortcutText, setShortcutText] = useState<string>()
@@ -25,7 +25,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     const [buttonFocus, setButtonFocus] = useState<boolean>(false)
     const removeListenerRef = useRef<Function>()
 
-
+    
     const setPrimaryOutput = (output : string) => {
         primaryAudioRef.current?.setSinkId(output)
     }
@@ -83,9 +83,9 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
             setShortcutText(shortcutString)
             setShortcut(shortcutString)
         }
-
+        
     }
-
+    
     const loadHotkey = () => {
         let key
         if (props.name) key = localStorage.getItem(props.name)
@@ -100,14 +100,14 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         setShortcut('')
         setShortcutText('')
         loadHotkey()
-    }, [props.name])
-
+    }, [props.name]) 
+    
     useEffect(() =>{
         setPrimaryOutput(props.outputs[0])
         setSecondaryOutput(props.outputs[1])
     }, [props.outputs, props.name])
-
-
+    
+    
     useEffect(() => {
         if (removeListenerRef.current) removeListenerRef.current() // Remove old listener
 
@@ -119,13 +119,13 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
         props.name && shortcut && localStorage.setItem(props.name, shortcut)
     }, [shortcut])
-
+    
     useEffect(() => {
 
         // Apply logarithmic scaling of linear 0 ... 1 scale to 0 ... 1 logarithmic (not perfectly accurate decibel scale)
         primaryAudioRef.current!.volume = Math.exp((Math.log(props.volume) / Math.log(10)) * 4)
         secondaryAudioRef.current!.volume = Math.exp((Math.log(props.virtualVolume) / Math.log(10)) * 4)
-
+        
     }, [props.volume, props.virtualVolume])
 
     useEffect(() => {
@@ -138,9 +138,9 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
     const handleButtonHover = (state: string) => {
         if (state === 'in') {
-            setShortcutText('Rightclick to enter hotkey')
+            setShortcutText('Rightclick to enter hotkey') 
         }
-
+        
         if (state === 'out') {
             setShortcutText(shortcut)
             setButtonFocus(false)
@@ -152,7 +152,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     <div>
         <audio ref={primaryAudioRef} src={ props.source } preload="auto"/>
         <audio ref={secondaryAudioRef} src={ props.source } preload="auto"/>
-        <button onClick={play}
+        <button onClick={play} 
                 className="pad"
                 onContextMenu={handleContext}
                 onMouseOut={() => handleButtonHover('out')}

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -10,7 +10,7 @@ interface PadProps {
     name: string | undefined;
     volume: number;
     virtualVolume: number;
-    registerPlayFunction?: (name: string, playFn: () => void);
+    registerPlayFunction?: (name: string, playFn: () => void) => void;
 }
 
 let keys : string[] = [] // Could also be converted to variable ref inside component

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useRef, useState, useCallback} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
+import Colorselect from './Colorselect'
 const { myIpcRenderer } = window
 
 
@@ -33,7 +34,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         secondaryAudioRef.current?.setSinkId(output)
     }
 
-    const play = useCallback(() => {
+    const play = () => {
         if (primaryAudioRef.current) {
             primaryAudioRef.current.pause();
             primaryAudioRef.current.currentTime = 0;
@@ -83,11 +84,11 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
             setShortcut(shortcutString)
         }
         
-    }, []); // primaryAudioRef and secondaryAudioRef are stable refs
+    }
     
-    const loadHotkey = useCallback(() => {
-        let key;
-        if (props.name) key = localStorage.getItem(props.name);
+    const loadHotkey = () => {
+        let key
+        if (props.name) key = localStorage.getItem(props.name)
         if (key) {
             setShortcut(key)
             setShortcutText(key)
@@ -95,13 +96,11 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         }
     }
 
-    }, [props.name, setShortcut, setShortcutText]);
-
     useEffect(() => {
         setShortcut('')
         setShortcutText('')
         loadHotkey()
-    }, [loadHotkey]); 
+    }, [props.name]) 
     
     useEffect(() =>{
         setPrimaryOutput(props.outputs[0])
@@ -114,12 +113,12 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
         removeListenerRef.current = myIpcRenderer.on('APP_keypressed', (args : string) => {
             if(shortcut === args) {
-                play(); // play is now memoized
+                play()
             }
         })
 
         props.name && shortcut && localStorage.setItem(props.name, shortcut)
-    }, [shortcut, play]); // Added play to dependency array
+    }, [shortcut])
     
     useEffect(() => {
 
@@ -131,9 +130,9 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
     useEffect(() => {
         if (props.name && props.registerPlayFunction) {
-            props.registerPlayFunction(props.name, play); // play is now memoized
+            props.registerPlayFunction(props.name, play);
         }
-    }, [props.name, props.source, props.registerPlayFunction, play]); // Added play to dependency array
+    }, [props.name, props.source, props.registerPlayFunction]); // play is stable, props.source ensures re-registration if source changes
 
 
 

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -4,14 +4,14 @@ const { myIpcRenderer } = window
 
 
 
-type PadProps = {
+interface PadProps {
     outputs: string[];
     source: string;
     name: string | undefined;
     volume: number;
     virtualVolume: number;
     registerPlayFunction?: (name: string, playFn: () => void);
-};
+}
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
 

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -4,14 +4,14 @@ const { myIpcRenderer } = window
 
 
 
-type PadProps = { // Changed to PascalCase for convention
+type PadProps = {
     outputs: string[];
     source: string;
     name: string | undefined;
     volume: number;
     virtualVolume: number;
-    registerPlayFunction?: (name: string, playFn: () => void); // Ensure this line ends with a semicolon
-}; // Ensure the type alias ends with a semicolon
+    registerPlayFunction?: (name: string, playFn: () => void);
+};
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
 

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -4,19 +4,18 @@ const { myIpcRenderer } = window
 
 
 
-type padProps = {
-    outputs : string[]
-    source: string,
-    name: string | undefined
-    key: number
-    volume: number
-    virtualVolume: number
-    registerPlayFunction?: (name: string, playFn: () => void)
-}
+type PadProps = { // Changed to PascalCase for convention
+    outputs: string[];
+    source: string;
+    name: string | undefined;
+    volume: number;
+    virtualVolume: number;
+    registerPlayFunction?: (name: string, playFn: () => void); // Ensure this line ends with a semicolon
+}; // Ensure the type alias ends with a semicolon
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
 
-const Pad : React.FunctionComponent<padProps> = (props : padProps) => {
+const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     const primaryAudioRef = useRef<ExtendedAudioElement>(null) 
     const secondaryAudioRef = useRef<ExtendedAudioElement>(null)
 

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -10,13 +10,13 @@ interface PadProps {
     name: string | undefined;
     volume: number;
     virtualVolume: number;
-    registerPlayFunction?: (name: string, playFn: () => void);
+    registerPlayFunction?: (name: string, playFn: () => void) => void;
 }
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
 
 const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
-    const primaryAudioRef = useRef<ExtendedAudioElement>(null) 
+    const primaryAudioRef = useRef<ExtendedAudioElement>(null)
     const secondaryAudioRef = useRef<ExtendedAudioElement>(null)
 
     const [shortcutText, setShortcutText] = useState<string>()
@@ -25,7 +25,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     const [buttonFocus, setButtonFocus] = useState<boolean>(false)
     const removeListenerRef = useRef<Function>()
 
-    
+
     const setPrimaryOutput = (output : string) => {
         primaryAudioRef.current?.setSinkId(output)
     }
@@ -83,9 +83,9 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
             setShortcutText(shortcutString)
             setShortcut(shortcutString)
         }
-        
+
     }
-    
+
     const loadHotkey = () => {
         let key
         if (props.name) key = localStorage.getItem(props.name)
@@ -100,14 +100,14 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         setShortcut('')
         setShortcutText('')
         loadHotkey()
-    }, [props.name]) 
-    
+    }, [props.name])
+
     useEffect(() =>{
         setPrimaryOutput(props.outputs[0])
         setSecondaryOutput(props.outputs[1])
     }, [props.outputs, props.name])
-    
-    
+
+
     useEffect(() => {
         if (removeListenerRef.current) removeListenerRef.current() // Remove old listener
 
@@ -119,13 +119,13 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
         props.name && shortcut && localStorage.setItem(props.name, shortcut)
     }, [shortcut])
-    
+
     useEffect(() => {
 
         // Apply logarithmic scaling of linear 0 ... 1 scale to 0 ... 1 logarithmic (not perfectly accurate decibel scale)
         primaryAudioRef.current!.volume = Math.exp((Math.log(props.volume) / Math.log(10)) * 4)
         secondaryAudioRef.current!.volume = Math.exp((Math.log(props.virtualVolume) / Math.log(10)) * 4)
-        
+
     }, [props.volume, props.virtualVolume])
 
     useEffect(() => {
@@ -138,9 +138,9 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
     const handleButtonHover = (state: string) => {
         if (state === 'in') {
-            setShortcutText('Rightclick to enter hotkey') 
+            setShortcutText('Rightclick to enter hotkey')
         }
-        
+
         if (state === 'out') {
             setShortcutText(shortcut)
             setButtonFocus(false)
@@ -152,7 +152,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     <div>
         <audio ref={primaryAudioRef} src={ props.source } preload="auto"/>
         <audio ref={secondaryAudioRef} src={ props.source } preload="auto"/>
-        <button onClick={play} 
+        <button onClick={play}
                 className="pad"
                 onContextMenu={handleContext}
                 onMouseOut={() => handleButtonHover('out')}

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -11,6 +11,7 @@ type padProps = {
     key: number
     volume: number
     virtualVolume: number
+    registerPlayFunction?: (name: string, playFn: () => void)
 }
 
 let keys : string[] = [] // Could also be converted to variable ref inside component
@@ -35,14 +36,21 @@ const Pad : React.FunctionComponent<padProps> = (props : padProps) => {
     }
 
     const play = () => {
-        if (primaryAudioRef.current?.paused) {
-            primaryAudioRef.current?.play()
-            secondaryAudioRef.current?.play()
-        } else {
-            primaryAudioRef.current?.pause()
-            primaryAudioRef.current!.currentTime = 0
-            secondaryAudioRef.current?.pause()
-            secondaryAudioRef.current!.currentTime = 0
+        if (primaryAudioRef.current) {
+            primaryAudioRef.current.pause();
+            primaryAudioRef.current.currentTime = 0;
+        }
+        if (secondaryAudioRef.current) {
+            secondaryAudioRef.current.pause();
+            secondaryAudioRef.current.currentTime = 0;
+        }
+
+        // Start playback
+        if (primaryAudioRef.current) {
+            primaryAudioRef.current.play().catch(error => console.error("Error playing primary audio:", error));
+        }
+        if (secondaryAudioRef.current) {
+            secondaryAudioRef.current.play().catch(error => console.error("Error playing secondary audio:", error));
         }
     }
 
@@ -120,6 +128,12 @@ const Pad : React.FunctionComponent<padProps> = (props : padProps) => {
         secondaryAudioRef.current!.volume = Math.exp((Math.log(props.virtualVolume) / Math.log(10)) * 4)
         
     }, [props.volume, props.virtualVolume])
+
+    useEffect(() => {
+        if (props.name && props.registerPlayFunction) {
+            props.registerPlayFunction(props.name, play);
+        }
+    }, [props.name, props.source, props.registerPlayFunction]); // play is stable, props.source ensures re-registration if source changes
 
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,9 +3431,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173:
-  version "1.0.30001720"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz"
-  integrity sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==
+  version "1.0.30001180"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz#67abcd6d1edf48fa5e7d1e84091d1d65ab76e33b"
+  integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,6 +1720,28 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-parser@*":
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.5.tgz#04ce9a3b677dc8bd681a17da1ab9835dc9d3ede4"
+  integrity sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cors@^2.8.17":
+  version "2.8.18"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.18.tgz#101e033b3ca06695f3d73c587cd7f9eb348135d1"
+  integrity sha512-nX3d0sxJW41CqQvfOzVG1NCTXfFDrDWIghCZncpHeWlVFd81zxB/DLhg7avFg6eHLCRX7ckBmoIIcqa++upvJA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/debug@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
@@ -1748,6 +1770,26 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/express-serve-static-core@^4.17.33":
+  version "4.19.6"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz#e01324c2a024ff367d92c66f48553ced0ab50267"
+  integrity sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
+"@types/express@^4.17.21":
+  version "4.17.22"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.22.tgz#14cfcf120f7eb56ebb8ca77b7fa9a14d21de7c96"
+  integrity sha512-eZUmSnhRX9YRSkplpz0N+k6NljUUn5l3EWZIKZvYzhvMphEuNiyyy1viH/ejgt66JWgALwC/gtSUAeQKtSwW/w==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/fs-extra@^9.0.1":
   version "9.0.6"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.6.tgz#488e56b77299899a608b8269719c1d133027a6ab"
@@ -1774,6 +1816,11 @@
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
   integrity sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==
+
+"@types/http-errors@*":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
+  integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
@@ -1811,6 +1858,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/mime@^1":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
+  integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
 
 "@types/mime@^2.0.3":
   version "2.0.3"
@@ -1857,6 +1909,16 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/qs@*":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.14.0.tgz#d8b60cecf62f2db0fb68e5e006077b9178b85de5"
+  integrity sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==
+
+"@types/range-parser@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
 "@types/react-dom@^16.9.8":
   version "16.9.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
@@ -1883,6 +1945,23 @@
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
   integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
+
+"@types/send@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.4.tgz#6619cd24e7270793702e4e6a4b958a9010cfc57a"
+  integrity sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/serve-static@*":
+  version "1.15.7"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.7.tgz#22174bbd74fb97fe303109738e9b5c2f3064f714"
+  integrity sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/node" "*"
+    "@types/send" "*"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -3846,6 +3925,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^5.0.0:
   version "5.2.1"
@@ -8407,7 +8494,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -12103,7 +12190,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,9 +3431,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173:
-  version "1.0.30001180"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz#67abcd6d1edf48fa5e7d1e84091d1d65ab76e33b"
-  integrity sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==
+  version "1.0.30001720"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz"
+  integrity sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This commit introduces a web interface that allows you to control the soundboard remotely from another device on the same local network.

Key changes include:

- **Express.js Web Server:** Integrated an Express.js server into the Electron main process (`electron/electron.ts`). This server runs on port 3001.
- **API Endpoints:**
    - `/get-sounds`: Serves a list of currently loaded sound files. The main process now maintains a static list of sounds, updated when a sound folder is selected.
    - `/play-sound/:soundName`: Receives a request to play a specific sound. This request is then relayed to the renderer process via IPC.
- **IPC for Web Playback:**
    - Added IPC channel `PLAY_SOUND_FROM_WEB` for communication from the main process to the renderer.
    - The renderer (`src/controller.tsx`) listens for this message and triggers playback of the specified sound.
- **Sound Playback Modification:**
    - The `play()` function in `src/pad.tsx` was updated to always restart the sound from the beginning, ensuring consistent behavior when triggered from the web interface or the local UI.
- **Web Interface (`public/remote.html`):**
    - A new HTML page that fetches the sound list from `/get-sounds`.
    - Dynamically creates buttons for each sound.
    - Allows you to input the IP address of the host machine.
    - Clicking a button on this page sends a request to `/play-sound/:soundName` on the host.
- **Dependencies:** Added `express`, `cors`, `@types/express`, and `@types/cors` to `package.json`.
- **Documentation:** Updated `README.md` with instructions on how to access and use the new web interface.

The implementation allows you to load sounds in the Electron application and then use a browser on another device (e.g., phone, tablet, laptop) on the same network to trigger these sounds on the host machine.