### PR TITLE
Visual feedback for playing sounds

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,6 +109,10 @@ button:active {
     
 }
 
+.pad.playing {
+    background-color: #a3be8c;
+}
+
 .pad:active {
     background-color:#af7360 ;
 }

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -37,6 +37,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
 
     const [buttonFocus, setButtonFocus] = useState<boolean>(false)
     const [localVolume, setLocalVolume] = useState<number>(1.0)
+    const [isPlaying, setIsPlaying] = useState<boolean>(false)
     const removeListenerRef = useRef<Function | null>(null)
 
     
@@ -262,7 +263,15 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     return (
     <div className="pad-container">
         {/* Source elements */}
-        <audio ref={primarySourceRef} src={ props.source } preload="auto" crossOrigin="anonymous" />
+        <audio
+            ref={primarySourceRef}
+            src={ props.source }
+            preload="auto"
+            crossOrigin="anonymous"
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onEnded={() => setIsPlaying(false)}
+        />
         <audio ref={secondarySourceRef} src={ props.source } preload="auto" crossOrigin="anonymous" />
 
         {/* Sink elements */}
@@ -270,7 +279,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         <audio ref={secondarySinkRef} preload="auto" />
 
         <button onClick={play} 
-                className="pad"
+                className={`pad ${isPlaying ? 'playing' : ''}`}
                 onContextMenu={handleContext}
                 onMouseOut={() => handleButtonHover('out')}
                 onMouseEnter={() => handleButtonHover('in')}


### PR DESCRIPTION
Implemented visual feedback for sound pads when they are active. Each pad now changes its background color to a slight green (Nord 14) while the sound is playing, providing the user with clear indication of which sounds are currently active.

---
*PR created automatically by Jules for task [12120612792436028151](https://jules.google.com/task/12120612792436028151) started by @Mejia-Jorge*