### PR TITLE
Add visual indicator for active sounds on pads

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,6 +113,10 @@ button:active {
     background-color:#af7360 ;
 }
 
+.pad.playing {
+    background-color: #a3be8c;
+}
+
 
 #controller {
     display: block;

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -36,6 +36,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     const [shortcut, setShortcut] = useState<string>('')
 
     const [buttonFocus, setButtonFocus] = useState<boolean>(false)
+    const [isPlaying, setIsPlaying] = useState<boolean>(false)
     const [localVolume, setLocalVolume] = useState<number>(1.0)
     const removeListenerRef = useRef<Function | null>(null)
 
@@ -262,7 +263,13 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
     return (
     <div className="pad-container">
         {/* Source elements */}
-        <audio ref={primarySourceRef} src={ props.source } preload="auto" crossOrigin="anonymous" />
+        <audio ref={primarySourceRef}
+               src={ props.source }
+               preload="auto"
+               crossOrigin="anonymous"
+               onPlay={() => setIsPlaying(true)}
+               onPause={() => setIsPlaying(false)}
+               onEnded={() => setIsPlaying(false)} />
         <audio ref={secondarySourceRef} src={ props.source } preload="auto" crossOrigin="anonymous" />
 
         {/* Sink elements */}
@@ -270,7 +277,7 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
         <audio ref={secondarySinkRef} preload="auto" />
 
         <button onClick={play} 
-                className="pad"
+                className={`pad ${isPlaying ? 'playing' : ''}`}
                 onContextMenu={handleContext}
                 onMouseOut={() => handleButtonHover('out')}
                 onMouseEnter={() => handleButtonHover('in')}


### PR DESCRIPTION
This change adds a visual indicator to each sound pad that changes its color to Nord green (#a3be8c) when the sound is currently playing. This is achieved by tracking the audio element's playing state in the Pad component and applying a conditional CSS class to the button.

---
*PR created automatically by Jules for task [8864423207605243863](https://jules.google.com/task/8864423207605243863) started by @Mejia-Jorge*