### PR TITLE
feat: add visual playing indicator and Web UI link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -85,6 +85,22 @@ header {
     opacity: 0.8;
 }
 
+.web-ui-link {
+    color: #88c0d0;
+    text-decoration: none;
+    text-align: center;
+    font-size: 0.9em;
+    padding: 5px;
+    border: 1px solid #88c0d0;
+    border-radius: 5px;
+    transition: all 0.2s ease;
+}
+
+.web-ui-link:hover {
+    background-color: #88c0d0;
+    color: #2e3440;
+}
+
 button {
     background-color: #3b4252;
     color: white;

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -201,6 +201,7 @@ const Controller : React.FunctionComponent = () => {
 
                 <div id="config">
                     <button onClick={handlePathSelection}>Select Audio Folder</button>
+                    <a href="http://localhost:3001/remote.html" target="_blank" rel="noreferrer" className="web-ui-link">Open Web UI</a>
                     <div id="outputs">
                         <select onChange={ handlePrimaryOutputChange } ref={primaryRef}>
                             {outputs && outputs.map((output, index) => 

--- a/src/pad.tsx
+++ b/src/pad.tsx
@@ -270,7 +270,13 @@ const Pad : React.FunctionComponent<PadProps> = (props : PadProps) => {
                onPlay={() => setIsPlaying(true)}
                onPause={() => setIsPlaying(false)}
                onEnded={() => setIsPlaying(false)} />
-        <audio ref={secondarySourceRef} src={ props.source } preload="auto" crossOrigin="anonymous" />
+        <audio ref={secondarySourceRef}
+               src={ props.source }
+               preload="auto"
+               crossOrigin="anonymous"
+               onPlay={() => setIsPlaying(true)}
+               onPause={() => setIsPlaying(false)}
+               onEnded={() => setIsPlaying(false)} />
 
         {/* Sink elements */}
         <audio ref={primarySinkRef} preload="auto" />


### PR DESCRIPTION
- Added .pad.playing class to App.css with Nord green color.
- Updated Pad component to track playing state on both primary and secondary audio elements.
- Applied .playing class to pad buttons during playback.
- Added a styled link to the Web UI in the Controller component.