### PR TITLE
Move Open Web UI button and show dynamic IP address

### DIFF
--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { app, BrowserWindow, ipcMain, dialog, globalShortcut, Tray, Menu, nativeImage } from 'electron'
 import fs from 'fs'
+import os from 'os'
 
 import mime from 'mime'
 import express from 'express'
@@ -238,6 +239,26 @@ export default class Main {
     }
 
 
+
+    private static getLocalIP() {
+        const interfaces = os.networkInterfaces();
+        for (const name of Object.keys(interfaces)) {
+            for (const iface of interfaces[name]!) {
+                if (iface.family === 'IPv4' && !iface.internal) {
+                    return iface.address;
+                }
+            }
+        }
+        return 'localhost';
+    }
+
+    private static listenerWebUI() {
+        ipcMain.handle('APP_getWebUIUrl', (event) => {
+            const port = 3001;
+            const ip = Main.getLocalIP();
+            return `http://${ip}:${port}/remote.html`;
+        });
+    }
 
     private static listenerVersion() {
         ipcMain.on('APP_getVersion', (event) => {
@@ -496,6 +517,7 @@ export default class Main {
         this.listenerRecording()
         this.listenerListFiles()
         this.listenerVersion()
+        this.listenerWebUI()
     }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -348,6 +348,13 @@ option {
 }
 
 
+#web-ui-container {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 0px;
+}
+
 #version {
     display: flex;
     width: 100%;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,16 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { jest, test } from '@jest/globals';
 
-// Define myIpcRenderer on window before anything else
-Object.defineProperty(window, 'myIpcRenderer', {
-  value: {
-    invoke: jest.fn(),
-    send: jest.fn(),
-    on: jest.fn(() => () => {}),
-  },
-  writable: true
-});
-
 // Mock subcomponents
 jest.mock('./controller', () => () => <div data-testid="controller" />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,29 @@ const Version : React.FunctionComponent = () => {
     )
 }
 
+const WebUILink : React.FunctionComponent = () => {
+    const [webUIUrl, setWebUIUrl] = useState<string>('')
+
+    useEffect(() => {
+        const myIpcRenderer = getIpc();
+        if (myIpcRenderer) {
+            myIpcRenderer.invoke('APP_getWebUIUrl').then((url: string) => {
+                setWebUIUrl(url)
+            })
+        }
+    }, [])
+
+    if (!webUIUrl) return null;
+
+    return (
+        <div id="web-ui-container">
+            <a href={webUIUrl} target="_blank" rel="noreferrer" className="web-ui-link">
+                Open Web UI ({webUIUrl})
+            </a>
+        </div>
+    )
+}
+
 const App : React.FunctionComponent = () => {
     
 
@@ -55,6 +78,7 @@ const App : React.FunctionComponent = () => {
             
             <Menu/>
             <Controller/>
+            <WebUILink/>
             <Version/>
         </div>
     )

--- a/src/controller.tsx
+++ b/src/controller.tsx
@@ -201,7 +201,7 @@ const Controller : React.FunctionComponent = () => {
 
                 <div id="config">
                     <button onClick={handlePathSelection}>Select Audio Folder</button>
-                    <a href="http://localhost:3001/remote.html" target="_blank" rel="noreferrer" className="web-ui-link">Open Web UI</a>
+
                     <div id="outputs">
                         <select onChange={ handlePrimaryOutputChange } ref={primaryRef}>
                             {outputs && outputs.map((output, index) => 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,11 +4,8 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
-Object.defineProperty(window, 'myIpcRenderer', {
-  value: {
-    invoke: jest.fn(),
-    send: jest.fn(),
-    on: jest.fn(() => () => {}),
-  },
-  writable: true
-});
+(window as any).myIpcRenderer = {
+  invoke: () => Promise.resolve(''),
+  send: () => {},
+  on: () => () => {},
+};


### PR DESCRIPTION
Moved the "Open Web UI" button to the bottom of the app, centered above the version number. The button now displays the actual local IP address and port (e.g., http://192.168.1.5:3001/remote.html) instead of just "Open Web UI", making it easier for users to know how to connect remotely. Added the necessary IPC communication and backend logic to retrieve the machine's local IP address.

---
*PR created automatically by Jules for task [8084215538157333896](https://jules.google.com/task/8084215538157333896) started by @Mejia-Jorge*