### PR TITLE
Center sound button grid in remote web interface

### DIFF
--- a/public/remote.html
+++ b/public/remote.html
@@ -19,7 +19,7 @@
             display: flex;
             flex-wrap: wrap;
             gap: 10px; /* Spacing between buttons */
-            justify-content: flex-start; /* Align buttons to the start */
+            justify-content: center; /* Align buttons to the center */
         }
         #sound-buttons-container button {
             width: 100px; /* Increased width */


### PR DESCRIPTION
The sound button grid in the remote web interface (`public/remote.html`) was previously aligned to the start (`flex-start`). This change updates the CSS to center the buttons horizontally using `justify-content: center`. 

Changes:
- Updated `#sound-buttons-container` in `public/remote.html` to include `justify-content: center`.
- Reverted accidental changes to `yarn.lock` caused by dependency installation during verification.
- Verified centering via a mock Express server and Playwright screenshot.

---
*PR created automatically by Jules for task [818731517116562663](https://jules.google.com/task/818731517116562663) started by @Mejia-Jorge*